### PR TITLE
Periodic Cleanup Sessions

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -33,7 +33,9 @@ func main() {
 	server := api.NewServer(api.GlobalSessionManager, api.GlobalGameManager, api.WithPort(port), api.WithStage(stage))
 
 	go server.GameManager.ManageGameTermination()
+	
 	go server.SessionManager.ManageCommunication()
+	go server.SessionManager.CleanUpPeriodically()
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("GET /battleship", server.HandleWs)

--- a/test/main_test.go
+++ b/test/main_test.go
@@ -31,6 +31,7 @@ func TestMain(m *testing.M) {
 
 		go server.GameManager.ManageGameTermination()
 		go server.SessionManager.ManageCommunication()
+		go server.SessionManager.CleanUpPeriodically()
 
 		mux := http.NewServeMux()
 		mux.HandleFunc("GET /battleship", server.HandleWs)


### PR DESCRIPTION
# Overview

Added the periodic cleanup of sessions map function for `SessionManager`. This ensures invalidating and removing the stale connections in the sessions map.