### PR TITLE
Add difficulty to resp join

### DIFF
--- a/api/handlers_api.go
+++ b/api/handlers_api.go
@@ -88,7 +88,7 @@ func (r *Request) HandleJoinPlayer() (mc.Message[mc.RespJoinGame], *mb.Game) {
 	r.Session.GameUuid = game.Uuid
 	r.Session.Player = joinPlayer
 
-	resp.AddPayload(mc.RespJoinGame{GameUuid: game.Uuid, PlayerUuid: joinPlayer.Uuid})
+	resp.AddPayload(mc.RespJoinGame{GameUuid: game.Uuid, PlayerUuid: joinPlayer.Uuid, GameDifficulty: game.Difficulty})
 	return resp, game
 }
 

--- a/api/session_manager_api.go
+++ b/api/session_manager_api.go
@@ -12,7 +12,7 @@ const (
 	// Assuming this capacity for the slice when
 	// we're cleaning up the sessions map.
 	assumedClosedConns               = 5
-	cleanupInterval    time.Duration = time.Minute * 20 
+	cleanupInterval    time.Duration = time.Minute * 20
 )
 
 type SessionManager struct {
@@ -33,7 +33,7 @@ func (sm *SessionManager) FindSession(sessionId string) (*Session, error) {
 	defer sm.mu.RUnlock()
 
 	session, prs := sm.Sessions[sessionId]
-	if !prs {	
+	if !prs {
 		return nil, cerr.ErrSessionNotFound(sessionId)
 	}
 

--- a/internal/error/error.go
+++ b/internal/error/error.go
@@ -41,7 +41,6 @@ func ErrValueNotGridInt() error {
 	return fmt.Errorf("the value is not of type GridInt")
 }
 
-
 // Create Game
 
 func ErrInvalidGameDifficulty() error {

--- a/models/battleship/grid.go
+++ b/models/battleship/grid.go
@@ -11,7 +11,6 @@ func NewCoordinates(x, y int) Coordinates {
 	return Coordinates{X: x, Y: y}
 }
 
-
 const (
 	GameGridSize = 5
 )

--- a/models/connection/message.go
+++ b/models/connection/message.go
@@ -2,8 +2,8 @@ package connection
 
 type NoPayload bool
 type Message[T any] struct {
-	Code    int     `json:"code"`
-	Payload T       `json:"payload,omitempty"`
+	Code    int      `json:"code"`
+	Payload T        `json:"payload,omitempty"`
 	Error   *RespErr `json:"error,omitempty"`
 }
 

--- a/models/connection/response_json.go
+++ b/models/connection/response_json.go
@@ -5,9 +5,9 @@ import (
 )
 
 type RespJoinGame struct {
-	GameUuid   string `json:"game_uuid"`
-	PlayerUuid string `json:"player_uuid"`
-  GameDifficulty int `json:"game_difficulty"`
+	GameUuid       string `json:"game_uuid"`
+	PlayerUuid     string `json:"player_uuid"`
+	GameDifficulty int    `json:"game_difficulty"`
 }
 
 type RespCreateGame struct {

--- a/models/connection/response_json.go
+++ b/models/connection/response_json.go
@@ -7,6 +7,7 @@ import (
 type RespJoinGame struct {
 	GameUuid   string `json:"game_uuid"`
 	PlayerUuid string `json:"player_uuid"`
+  GameDifficulty int `json:"game_difficulty"`
 }
 
 type RespCreateGame struct {

--- a/test/ws_test.go
+++ b/test/ws_test.go
@@ -107,9 +107,9 @@ func TestJoinPlayer(t *testing.T) {
 		{
 			name:         "valid game uuid",
 			expectedCode: mc.CodeJoinGame,
-			reqPayload:  mc.Message[mc.ReqJoinGame]{Code: mc.CodeJoinGame, Payload: mc.ReqJoinGame{GameUuid: GameUuid}},
-			respPayload: mc.NewMessage[mc.RespJoinGame](mc.CodeJoinGame),
-			conn:        JoinConn,
+			reqPayload:   mc.Message[mc.ReqJoinGame]{Code: mc.CodeJoinGame, Payload: mc.ReqJoinGame{GameUuid: GameUuid}},
+			respPayload:  mc.NewMessage[mc.RespJoinGame](mc.CodeJoinGame),
+			conn:         JoinConn,
 		},
 		{
 			name:         "invalid game uuid",


### PR DESCRIPTION
We need `gameDifficulty` in `RespJoinGame` struct in order to set the grid size for the `joinPlayer` on client side